### PR TITLE
fix(item-update): visibility of range spanning items not always correct

### DIFF
--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -813,7 +813,7 @@ class Group {
    */
   _resetSubgroups() {
     for (const subgroup in this.subgroups) {
-      if (this.subgroups.hasOwnProperty(subgroup)) {
+      if (Object.prototype.hasOwnProperty.call(this.subgroups, subgroup)) {
         this.subgroups[subgroup].visible = false;
         this.subgroups[subgroup].height = 0;
       }
@@ -924,14 +924,6 @@ class Group {
       else                          {return  1;}
     };
 
-    // this function is used to do the binary search for items having start and end dates (range).
-    const endSearchFunction = data => {
-      const {start, end} = data;
-      if      (end < lowerBound)    {return -1;}
-      else if (start <= upperBound) {return  0;}
-      else                          {return  1;}
-    }
-
     // first check if the items that were in view previously are still in view.
     // IMPORTANT: this handles the case for the items with startdate before the window and enddate after the window!
     // also cleans up invisible items.
@@ -947,20 +939,9 @@ class Group {
     // trace the visible items from the inital start pos both ways until an invisible item is found, we only look at the start values.
     this._traceVisible(initialPosByStart, orderedItems.byStart, visibleItems, visibleItemsLookup, item => item.data.start < lowerBound || item.data.start > upperBound);
 
-    // if the window has changed programmatically without overlapping the old window, the ranged items with start < lowerBound and end > upperbound are not shown.
-    // We therefore have to brute force check all items in the byEnd list
-    if (this.checkRangedItems == true) {
-      this.checkRangedItems = false;
-      for (let i = 0; i < orderedItems.byEnd.length; i++) {
-        this._checkIfVisibleWithReference(orderedItems.byEnd[i], visibleItems, visibleItemsLookup, range);
-      }
-    }
-    else {
-      // we do a binary search for the items that have defined end times.
-      const initialPosByEnd = util.binarySearchCustom(orderedItems.byEnd, endSearchFunction, 'data');
-
-      // trace the visible items from the inital start pos both ways until an invisible item is found, we only look at the end values.
-      this._traceVisible(initialPosByEnd, orderedItems.byEnd, visibleItems, visibleItemsLookup, item => item.data.end < lowerBound || item.data.start > upperBound);
+    // check every item with end date if is visible. Binary search would be the most efficient, but it would leave out items that start before the range and end after the range.
+    for (let i = 0; i < orderedItems.byEnd.length; i++) {
+      this._checkIfVisibleWithReference(orderedItems.byEnd[i], visibleItems, visibleItemsLookup, range);
     }
 
     const redrawQueue = {};


### PR DESCRIPTION
This is the copy of a PR to the origin Repo because we cannot wait for it to be merged. Original PR can be found here: https://github.com/visjs/vis-timeline/pull/1846

> Items starting before the visible range and ending after it were not always shown if zoomed in too much because of the binary search used for it. I tried to fix the conditions but I could not get it to work with a binary search (maybe someone has a better way?). Also, different approaches like spatial index logic fixed the problem but did not improve performance. So I kept it simple and removed the binary search case for items that have an end time and always brute force check them for visibility. This may worsen performance when having many items with end times but in my manual testing (private repo) it is not performant either way.
> 
> Question: Should we make this fix optional per config because it may have a bigger impact?
> 
> Module: timeline/component/group
> 
> Fixes https://github.com/visjs/vis-timeline/issues/1657